### PR TITLE
Added resend button for tickets

### DIFF
--- a/camper/barcamps/__init__.py
+++ b/camper/barcamps/__init__.py
@@ -110,6 +110,7 @@ class BarcampModule(Module):
         URL('/<slug>/admin/tickets/config', 'admin_ticketconfig',               ticketeditor.TicketingConfig),
         URL('/<slug>/admin/tickets/users',  'admin_ticketlist',                 ticketlist.TicketList),
         URL('/<slug>/admin/tickets/<ticket_id>/cancel','admin_ticketcancel',        ticketlist.TicketCancel),
+        URL('/<slug>/admin/tickets/<ticket_id>/resend','admin_ticketresend',        ticketlist.TicketResend),
 
         URL('/<slug>/events',               'user_events',                      user_events.Events),
         URL('/<slug>/events/<eid>',         'user_event',                       user_events.Event),

--- a/camper/barcamps/templates/admin/ticketlist.html
+++ b/camper/barcamps/templates/admin/ticketlist.html
@@ -37,6 +37,8 @@
                     <a href="{{url_for('.admin_ticketcancel', slug = slug, ticket_id = ticket._id)}}" 
                         class="btn btn-xs btn-danger"><i class="fa fa-ban"></i> {{_('Cancel Ticket')}}</a>
                 {% elif typ=="confirmed" %}
+                    <a href="{{url_for('.admin_ticketresend', slug = slug, ticket_id = ticket._id, m='POST')}}" 
+                        class="btn btn-xs btn-info"><i class="fa fa-ban"></i> {{_('Send Ticket')}}</a>
                     <a href="{{url_for('.admin_ticketcancel', slug = slug, ticket_id = ticket._id)}}" 
                         class="btn btn-xs btn-danger"><i class="fa fa-ban"></i> {{_('Cancel Ticket')}}</a>
                 {% elif typ=="cancel_request" %}

--- a/camper/barcamps/templates/admin/ticketlist.html
+++ b/camper/barcamps/templates/admin/ticketlist.html
@@ -37,8 +37,8 @@
                     <a href="{{url_for('.admin_ticketcancel', slug = slug, ticket_id = ticket._id)}}" 
                         class="btn btn-xs btn-danger"><i class="fa fa-ban"></i> {{_('Cancel Ticket')}}</a>
                 {% elif typ=="confirmed" %}
-                    <a href="{{url_for('.admin_ticketresend', slug = slug, ticket_id = ticket._id, m='POST')}}" 
-                        class="btn btn-xs btn-info"><i class="fa fa-ban"></i> {{_('Send Ticket')}}</a>
+                    <a href="{{url_for('.admin_ticketresend', slug = slug, ticket_id = ticket._id, method='POST', _append=True)}}" 
+                        class="btn btn-xs btn-info"><i class="fa fa-envelope"></i> {{_('Send Ticket')}}</a>
                     <a href="{{url_for('.admin_ticketcancel', slug = slug, ticket_id = ticket._id)}}" 
                         class="btn btn-xs btn-danger"><i class="fa fa-ban"></i> {{_('Cancel Ticket')}}</a>
                 {% elif typ=="cancel_request" %}

--- a/camper/barcamps/ticketlist.py
+++ b/camper/barcamps/ticketlist.py
@@ -169,6 +169,13 @@ class TicketResend(BarcampBaseHandler):
     def post(self, slug, ticket_id):
         """show the form"""
 
+        ticket_db = self.app.config.dbs.tickets
+        try:
+            ticket = ticket_db.get(ObjectId(ticket_id))
+        except ObjectNotFound:
+            self.log.error("unknown ticket id", ticket_id = ticket_id)
+            raise werkzeug.exceptions.NotFound()
+
         ticketservice = TicketService(self, self.user)
         ticketservice.send_welcome_mail(ticket.ticketclass_id, ticket_id)
         self.flash(self._('Welcome mail send to user.'), category="info")

--- a/camper/barcamps/ticketlist.py
+++ b/camper/barcamps/ticketlist.py
@@ -159,3 +159,17 @@ class TicketCancel(BarcampBaseHandler):
     post = get
 
 
+
+class TicketResend(BarcampBaseHandler):
+    """send the welcome mail again"""
+
+    @logged_in()
+    @is_admin()
+    @ensure_barcamp()
+    def post(self, slug, ticket_id):
+        """show the form"""
+
+        ticketservice = TicketService(self, self.user)
+        ticketservice.send_welcome_mail(ticket.ticketclass_id, ticket_id)
+        self.flash(self._('Welcome mail send to user.'), category="info")
+        return redirect(self.url_for('barcamps.admin_ticketlist', slug = slug))

--- a/camper/services/ticketing.py
+++ b/camper/services/ticketing.py
@@ -264,13 +264,23 @@ class TicketService(object):
         ticket['workflow'] = "confirmed"
         ticket.save()
         self.log.info("ticket approved", ticket = ticket)
+        self.send_welcome_mail(tc_id, ticket_id)
 
+        return "confirmed"
+
+    def send_welcome_mail(self, tc_id, ticket_id):
+        """send the welcome mail with the link to the pdf ticket to the user
+
+        :param tc_id: the ticket class id
+        :param ticket_id: the id of the ticket to send
+
+        """
+        ticket_class, ticket = self._check_ticket(tc_id, ticket_id)
+
+        # retrieve user
         uid = ticket['user_id']
         user = self.userbase.get_user_by_id(uid)
         self.log.debug("found user", uid = uid, email = user.email)
-
-        # send welcome mail
-        #ticket_pdf = self.create_pdf_ticket(ticket, ticket_class, user)
 
         self.mail_template("ticket_confirmed",
             ticket_pdf = None,
@@ -283,7 +293,7 @@ class TicketService(object):
             fullname = user.fullname,
             user = user
         )
-        return "confirmed"
+
 
 
     def user_cancel_ticket(self, tc_id, ticket_id, reason = ""):


### PR DESCRIPTION
The admin can now send the welcome mail with the ticket to a user again. This is useful in general in case the mail went missing but also to correct the bug where the mails were eventually sent to the admin instead of the user.