### PR TITLE
Fix inconsistent language: 'Barcamp löschen' -> 'delete barcamp'

### DIFF
--- a/camper/templates/admin_master.html
+++ b/camper/templates/admin_master.html
@@ -67,7 +67,7 @@
                     <li class="{{'active' if menu=='mail_templates'}}"><a href="{{url_for('barcamps.email_template_editor', slug=slug)}}"><i class="fa fa-envelope"></i> {{_('edit mail templates')}}</a></li>
                     <li><a href="{{url_for('barcamps.registration_data_export', slug=slug)}}"><i class="fa fa-download"></i> {{_('download participants')}}</a></li>
                     <li><a href="{{url_for('barcamps.admin_duplicate', slug=slug)}}"><i class="fa fa-copy"></i> {{_('duplicate barcamp')}}</a></li>
-                    <li><a href="{{url_for('barcamps.delete', slug=slug)}}"><i class="fa fa-trash"></i> {{_('Barcamp löschen')}}</a></li>
+                    <li><a href="{{url_for('barcamps.delete', slug=slug)}}"><i class="fa fa-trash"></i> {{_('delete barcamp')}}</a></li>
                 </ul>
             </nav>
         </div>

--- a/camper/translations/de/LC_MESSAGES/messages.po
+++ b/camper/translations/de/LC_MESSAGES/messages.po
@@ -3965,8 +3965,8 @@ msgid "duplicate barcamp"
 msgstr "Barcamp duplizieren"
 
 #: templates/admin_master.html:70
-msgid "Barcamp löschen"
-msgstr ""
+msgid "delete barcamp"
+msgstr "Barcamp löschen"
 
 #: templates/admin_master.html:79
 msgid "hide details"

--- a/camper/translations/en/LC_MESSAGES/messages.po
+++ b/camper/translations/en/LC_MESSAGES/messages.po
@@ -3707,7 +3707,7 @@ msgid "duplicate barcamp"
 msgstr ""
 
 #: templates/admin_master.html:70
-msgid "Barcamp löschen"
+msgid "delete barcamp"
 msgstr ""
 
 #: templates/admin_master.html:79


### PR DESCRIPTION
I think there might be more similar problems, perhaps untranslated strings left in templates (I couldn't find any other german message id).